### PR TITLE
Update 20230311201746_setup-vector-store.sql

### DIFF
--- a/supabase/migrations/20230311201746_setup-vector-store.sql
+++ b/supabase/migrations/20230311201746_setup-vector-store.sql
@@ -20,7 +20,7 @@ begin
   select
     id,
     content,
-    metadata,
+    jsonb_set(metadata,'{record_id}'::text[],('"' || id || '"')::jsonb, true) metadata,
     1 - (documents.embedding <=> query_embedding) as similarity
   from documents
   order by documents.embedding <=> query_embedding


### PR DESCRIPTION
This adds the ID value of the row the document belongs to into the metadata so it is fetched as part of every element in the  Document[] array.  This is because, out of the box from LangChain. Document object only brings in:     
pageContent: string;
metadata: Metadata; 

I found myself needing to keep track of these records in the database for my needs and this change helped me avoid multiple trips to DB when using LangChain libraries.

The same change can be added to the kw_match_documents_2 function as well.
It would look like below with the escapes for the quotes as the whole script is in quotes.

jsonb_set(metadata,''{record_id}''::text[],(''"'' || id || ''"'')::jsonb, true) metadata,

